### PR TITLE
debian: build documentation package only for indep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Build-Depends:
  cmake,
  libcmocka-dev,
  git,
+Build-Depends-Indep:
  pandoc,
  pandoc-plantuml-filter,
  graphviz,

--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,10 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all optimize=-lto
 %:
 	dh $@ --buildsystem=cmake --builddirectory=debian/build
 
-override_dh_auto_build:
+override_dh_auto_build-arch:
+	dh_auto_build -- all
+
+override_dh_auto_build-indep:
 	dh_auto_build -- all cmocka_extensions_doc
 
 override_dh_install:


### PR DESCRIPTION
Documentation package should be build as architecture-independent packages (Architecture: all). Thus, specific dependencies on it should be marked as build independent and documentation build arguments should only be set for build-indep debianhelper steps.