### PR TITLE
debian.native: set cmocka-extensions section to devel

### DIFF
--- a/debian.native/control
+++ b/debian.native/control
@@ -1,5 +1,5 @@
 Source: cmocka-extensions
-Section: admin
+Section: devel
 Priority: optional
 Maintainer: Isaac True <isaac.true@emlix.com>
 Build-Depends:


### PR DESCRIPTION
To be consistant with cmocka package section.
https://salsa.debian.org/debian/cmocka/-/blame/debian/1.1.7-3/debian/control?ref_type=tags#L2